### PR TITLE
ResourceConverter fails when resouce contains list properties

### DIFF
--- a/src/WebApi.HALight/Converters/ResourceConverter.cs
+++ b/src/WebApi.HALight/Converters/ResourceConverter.cs
@@ -85,7 +85,7 @@ namespace WebApi.HALight.Converters
                 var value = nonResourceProperty.GetValue(currentResource);
                 if (value != null && value.GetType().IsClass && value.GetType() != typeof(string))
                 {
-                    node.Add(ToCamelCase(nonResourceProperty.Name), JObject.FromObject(value));
+                    node.Add(ToCamelCase(nonResourceProperty.Name), JToken.FromObject(value));
                 }
                 else
                 {


### PR DESCRIPTION
Issue: 
JObject.FromObject() fails when value is a list.
Fix: 
Replaced it with JToken.FromObject() which returns a more generic JToken object which can be both JArray and JObject. 
